### PR TITLE
Add AI agent discovery and markdown content negotiation

### DIFF
--- a/app/.well-known/api-catalog/route.ts
+++ b/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server'
+
+const SITE = 'https://www.caldera.agency'
+
+export function GET() {
+  const catalog = {
+    linkset: [
+      {
+        anchor: `${SITE}/api/contact`,
+        'service-desc': [
+          {
+            href: `${SITE}/llms.txt`,
+            type: 'text/plain',
+          },
+        ],
+        'service-doc': [
+          {
+            href: `${SITE}/contact`,
+            type: 'text/html',
+          },
+        ],
+      },
+      {
+        anchor: `${SITE}/api/prototype`,
+        'service-desc': [
+          {
+            href: `${SITE}/llms.txt`,
+            type: 'text/plain',
+          },
+        ],
+        'service-doc': [
+          {
+            href: `${SITE}/contact`,
+            type: 'text/html',
+          },
+        ],
+      },
+    ],
+  }
+
+  return NextResponse.json(catalog, {
+    headers: {
+      'Content-Type': 'application/linkset+json',
+      'Cache-Control': 'public, max-age=86400',
+    },
+  })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { Analytics } from "@vercel/analytics/next"
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import StructuredData from "@/components/StructuredData"
 import NavTracker from "@/components/NavTracker"
+import WebMCP from "@/components/WebMCP"
 
 const geistSans = localFont({
   src: "./fonts/geist-latin.woff2",
@@ -105,6 +106,7 @@ export default function RootLayout({
         <StructuredData />
         <GoogleAnalytics />
         <CookieBanner />
+        <WebMCP />
        
         {children}
         <Analytics />

--- a/components/WebMCP.tsx
+++ b/components/WebMCP.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// WebMCP (Web Model Context) lets browser-based AI agents discover and call
+// site actions directly. The API is experimental and only present in
+// agent-enabled browsers, so everything here is feature-detected and a no-op
+// elsewhere. Tools map 1:1 to the existing /api/contact and /api/prototype
+// JSON endpoints, so an agent can do exactly what a human can via the forms.
+
+// Minimal shape of the proposed navigator.modelContext API. Declared locally
+// because it is not yet part of the standard DOM lib types.
+type McpToolResult = { content: Array<{ type: 'text'; text: string }> }
+
+interface McpTool {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  execute: (args: Record<string, unknown>) => Promise<McpToolResult>
+}
+
+interface ModelContext {
+  provideContext?: (context: { tools: McpTool[] }) => void
+  registerTool?: (tool: McpTool) => void
+}
+
+function getModelContext(): ModelContext | undefined {
+  if (typeof navigator === 'undefined') return undefined
+  return (navigator as Navigator & { modelContext?: ModelContext }).modelContext
+}
+
+async function postJson(path: string, body: Record<string, unknown>): Promise<McpToolResult> {
+  try {
+    const res = await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const data = await res.json().catch(() => ({}))
+    const text =
+      (data && (data.message || data.error)) ||
+      (res.ok ? 'Request submitted successfully.' : 'Request failed.')
+    return { content: [{ type: 'text', text }] }
+  } catch {
+    return {
+      content: [
+        { type: 'text', text: 'Could not reach Caldera Agency. Please try again or email contact@caldera.agency.' },
+      ],
+    }
+  }
+}
+
+const tools: McpTool[] = [
+  {
+    name: 'submit_contact_inquiry',
+    description:
+      "Send a contact inquiry to Caldera Agency, a website agency for solo consultants. Use this when a user wants to get in touch, ask a question, or start a project.",
+    inputSchema: {
+      type: 'object',
+      required: ['name', 'email'],
+      properties: {
+        name: { type: 'string', description: 'Full name of the person reaching out' },
+        email: { type: 'string', description: 'Contact email address' },
+        message: { type: 'string', description: 'The inquiry or message' },
+        linkedin: { type: 'string', description: 'Optional LinkedIn profile URL' },
+        website: { type: 'string', description: 'Optional current website URL' },
+      },
+    },
+    execute: (args) =>
+      postJson('/api/contact', {
+        name: args.name,
+        email: args.email,
+        // Always send a message key so the API treats this as a full inquiry.
+        message: args.message ?? '',
+        linkedin: args.linkedin,
+        website: args.website,
+      }),
+  },
+  {
+    name: 'request_free_prototype',
+    description:
+      "Request a free website prototype from Caldera Agency. Caldera researches the consultant's background and builds a working prototype before any payment. Use this when a user wants to start the free prototype process.",
+    inputSchema: {
+      type: 'object',
+      required: ['linkedin', 'email'],
+      properties: {
+        linkedin: { type: 'string', description: "The consultant's LinkedIn profile URL" },
+        email: { type: 'string', description: 'Contact email address' },
+      },
+    },
+    execute: (args) =>
+      postJson('/api/prototype', {
+        linkedin: args.linkedin,
+        email: args.email,
+      }),
+  },
+]
+
+export default function WebMCP() {
+  useEffect(() => {
+    const ctx = getModelContext()
+    if (!ctx) return
+
+    try {
+      if (typeof ctx.provideContext === 'function') {
+        ctx.provideContext({ tools })
+      } else if (typeof ctx.registerTool === 'function') {
+        // Fallback for the per-tool registration variant of the API.
+        tools.forEach((tool) => ctx.registerTool!(tool))
+      }
+    } catch {
+      // Experimental API: never let a registration failure affect the page.
+    }
+  }, [])
+
+  return null
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const MARKDOWN_PAGES: Record<string, string> = {
+  '/': 'home',
+  '/about': 'about',
+  '/work': 'work',
+  '/process': 'process',
+  '/contact': 'contact',
+  '/best-website-agency-for-consultants': 'flagship',
+}
+
+const SITE = 'https://www.caldera.agency'
+
+function homeMarkdown() {
+  return `# Caldera Agency
+
+> Done-for-you websites for solo consultants. We research your background, write the copy, and design, build, and host a fully custom site that gives you complete control of your personal brand and digital presence. You see a free working prototype before you pay anything.
+
+## What We Do
+
+Caldera Agency builds websites exclusively for solo and independent consultants — fractional CFOs, executive coaches, leadership coaches, supply-chain advisors, healthcare consultants, and similar experts. Every site is fully custom, built from scratch around your vision, with no complexity ceiling.
+
+## How It Works
+
+1. **Share your LinkedIn** — we research your background, positioning, and market.
+2. **Free prototype** — we build a working prototype before you pay anything.
+3. **Refine and launch** — we iterate with you and ship a polished, enterprise-grade site.
+
+## What's Included
+
+- Research and copywriting
+- Custom design and development
+- Domain setup and analytics
+- One year of hosting and support
+
+## Client Testimonials
+
+- **Mark S. Piazza**, Fractional CFO & Financial Advisor — "Caldera Agency didn't just build me a website, they helped me formally launch my entrepreneurial practice with clarity and credibility."
+- **Tim Scott**, Founder, True North Supply Chain Advisory — "They are very responsive, creative and were able to take my desired content and feedback to create an end product that far exceeded my expectations."
+- **Dr. Ron Paul**, Founder, Polaris Leadership Institute — "The experience felt like a true partnership, and the value of the service far exceeded the cost."
+
+## Links
+
+- [Case Studies](${SITE}/work)
+- [Process](${SITE}/process)
+- [About](${SITE}/about)
+- [Contact](${SITE}/contact)
+- Email: contact@caldera.agency
+`
+}
+
+function aboutMarkdown() {
+  return `# About Caldera Agency
+
+Caldera Agency was founded by Stefanos Bellos, who spent thousands of hours at the Dialectica expert network connecting consultants with investors and global enterprises. That experience showed him that independent consultants consistently struggle with one thing: presenting themselves online with the same credibility they bring to their work.
+
+Caldera exists to solve that. We build websites exclusively for solo and independent consultants — fully custom, done-for-you sites that give you complete control of your personal brand and digital presence.
+
+## Contact
+
+- Email: contact@caldera.agency
+- Website: ${SITE}
+`
+}
+
+function workMarkdown() {
+  return `# Case Studies — Caldera Agency
+
+Caldera builds websites for solo consultants. Here are some of the sites we've built:
+
+- **Mark S. Piazza** — Fractional CFO & Financial Advisor
+- **Dr. Ron Paul** — Polaris Leadership Institute (leadership coaching)
+- **Tim Scott** — True North Supply Chain Advisory
+
+Each site is fully custom and built from scratch around the client's vision.
+
+Visit [${SITE}/work](${SITE}/work) to see live examples.
+`
+}
+
+function processMarkdown() {
+  return `# Our Process — Caldera Agency
+
+1. **Share your LinkedIn** — we research your background, positioning, and competitive landscape.
+2. **Free working prototype** — we design and build a real, working version of your website before you pay anything.
+3. **Refine together** — we iterate based on your feedback until every detail is right.
+4. **Launch** — we handle domain, analytics, and deployment. You go live.
+
+Everything is included: research, copywriting, design, development, domain setup, analytics, and one year of hosting and support.
+
+Visit [${SITE}/process](${SITE}/process) for the full breakdown.
+`
+}
+
+function contactMarkdown() {
+  return `# Contact Caldera Agency
+
+Ready to get your consultant website? Reach out:
+
+- **Email**: contact@caldera.agency
+- **Website**: ${SITE}/contact
+
+You can also request a free prototype directly at [${SITE}/contact](${SITE}/contact) — just share your LinkedIn and email.
+`
+}
+
+function flagshipMarkdown() {
+  return `# Best Website Agency for Consultants — Caldera Agency
+
+Caldera Agency is a website agency built specifically for solo and independent consultants. We research your background, write your copy, and design, build, and host a fully custom site.
+
+## Why Caldera?
+
+- **Consultant-only focus** — we understand the positioning challenges solo consultants face.
+- **Free prototype first** — you see a working version of your site before paying anything.
+- **No templates** — every site is built from scratch, no matter the complexity.
+- **All-inclusive** — research, copywriting, design, development, hosting, and support.
+
+## Who We Work With
+
+Fractional CFOs, executive coaches, leadership coaches, supply-chain and operations advisors, healthcare consultants, and similar independent experts.
+
+Learn more at [${SITE}/best-website-agency-for-consultants](${SITE}/best-website-agency-for-consultants).
+`
+}
+
+const markdownGenerators: Record<string, () => string> = {
+  home: homeMarkdown,
+  about: aboutMarkdown,
+  work: workMarkdown,
+  process: processMarkdown,
+  contact: contactMarkdown,
+  flagship: flagshipMarkdown,
+}
+
+export function middleware(request: NextRequest) {
+  const accept = request.headers.get('accept') ?? ''
+  const pathname = request.nextUrl.pathname
+  const pageKey = MARKDOWN_PAGES[pathname]
+
+  if (pageKey && accept.includes('text/markdown') && !accept.includes('text/html')) {
+    const generator = markdownGenerators[pageKey]
+    if (generator) {
+      const md = generator()
+      return new NextResponse(md, {
+        headers: {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          'x-markdown-tokens': String(md.split(/\s+/).length),
+        },
+      })
+    }
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/', '/about', '/work', '/process', '/contact', '/best-website-agency-for-consultants'],
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,24 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'media.licdn.com' },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Link',
+            value: [
+              '</.well-known/api-catalog>; rel="api-catalog"',
+              '</llms.txt>; rel="service-doc"; type="text/plain"',
+              '</.well-known/agent-skills/index.json>; rel="agent-skills"',
+              '</.well-known/mcp/server-card.json>; rel="mcp-server-card"',
+            ].join(', '),
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       // The blog has been retired. Redirect every old blog URL to the flagship page.

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2.0/index.json",
+  "skills": [
+    {
+      "name": "contact-form",
+      "type": "api",
+      "description": "Submit a contact inquiry to Caldera Agency. Accepts name, email, and an optional message.",
+      "url": "https://www.caldera.agency/api/contact",
+      "method": "POST",
+      "input": {
+        "content_type": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["name", "email"],
+          "properties": {
+            "name": { "type": "string", "description": "Full name of the person reaching out" },
+            "email": { "type": "string", "format": "email", "description": "Contact email address" },
+            "message": { "type": "string", "description": "Optional message or inquiry" },
+            "linkedin": { "type": "string", "description": "Optional LinkedIn profile URL" },
+            "website": { "type": "string", "description": "Optional current website URL" }
+          }
+        }
+      }
+    },
+    {
+      "name": "request-prototype",
+      "type": "api",
+      "description": "Request a free website prototype from Caldera Agency. Share your LinkedIn profile and email to get started.",
+      "url": "https://www.caldera.agency/api/prototype",
+      "method": "POST",
+      "input": {
+        "content_type": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["linkedin", "email"],
+          "properties": {
+            "linkedin": { "type": "string", "description": "LinkedIn profile URL" },
+            "email": { "type": "string", "format": "email", "description": "Contact email address" }
+          }
+        }
+      }
+    },
+    {
+      "name": "site-information",
+      "type": "content",
+      "description": "Read about Caldera Agency — a website agency for solo consultants. Includes service details, process, case studies, and FAQs.",
+      "url": "https://www.caldera.agency/llms.txt"
+    },
+    {
+      "name": "case-studies",
+      "type": "content",
+      "description": "View live consultant websites built by Caldera Agency, with client testimonials.",
+      "url": "https://www.caldera.agency/work"
+    }
+  ]
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,45 @@
+{
+  "serverInfo": {
+    "name": "Caldera Agency",
+    "version": "1.0.0",
+    "description": "Done-for-you websites for solo consultants. Caldera researches your background, writes your copy, and builds a fully custom site."
+  },
+  "url": "https://www.caldera.agency",
+  "capabilities": {
+    "tools": [
+      {
+        "name": "submit_contact_form",
+        "description": "Submit a contact inquiry to Caldera Agency",
+        "inputSchema": {
+          "type": "object",
+          "required": ["name", "email"],
+          "properties": {
+            "name": { "type": "string", "description": "Full name" },
+            "email": { "type": "string", "format": "email", "description": "Email address" },
+            "message": { "type": "string", "description": "Optional message" }
+          }
+        }
+      },
+      {
+        "name": "request_free_prototype",
+        "description": "Request a free website prototype for your consulting practice",
+        "inputSchema": {
+          "type": "object",
+          "required": ["linkedin", "email"],
+          "properties": {
+            "linkedin": { "type": "string", "description": "LinkedIn profile URL" },
+            "email": { "type": "string", "format": "email", "description": "Email address" }
+          }
+        }
+      }
+    ],
+    "resources": [
+      {
+        "name": "llms_txt",
+        "description": "Machine-readable summary of Caldera Agency for LLMs and AI agents",
+        "uri": "https://www.caldera.agency/llms.txt",
+        "mimeType": "text/plain"
+      }
+    ]
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -40,3 +40,6 @@ User-agent: *
 Disallow: /chad-pollitt.html
 
 Sitemap: https://www.caldera.agency/sitemap.xml
+
+# AI content usage preferences (Content Signals)
+Content-Signal: ai-train=no, search=yes, ai-input=yes


### PR DESCRIPTION
## Summary
This PR adds support for AI agent discovery and interaction by implementing multiple agent-facing APIs and content formats. The changes enable AI agents to discover Caldera's services, request prototypes, submit contact inquiries, and access site content in machine-readable formats.

## Key Changes

- **Middleware for markdown content negotiation** (`middleware.ts`): Added Next.js middleware that serves markdown versions of key pages when clients request `text/markdown` content type. Includes markdown generators for home, about, work, process, contact, and flagship pages.

- **WebMCP component** (`components/WebMCP.tsx`): Implemented a client-side component that registers tools with the experimental `navigator.modelContext` API, allowing browser-based AI agents to discover and call the contact and prototype request endpoints directly.

- **Agent skills manifest** (`public/.well-known/agent-skills/index.json`): Added standardized agent skills definition following the agentskills.io schema, describing the contact form, prototype request, and content endpoints.

- **MCP server card** (`public/.well-known/mcp/server-card.json`): Added Model Context Protocol server metadata for AI agent discovery, including tool definitions and resource URIs.

- **API catalog endpoint** (`app/.well-known/api-catalog/route.ts`): Created a new route that serves an RFC 9264 linkset catalog describing the contact and prototype APIs with references to documentation.

- **HTTP Link headers** (`next.config.ts`): Added Link headers to all responses pointing to the API catalog, agent skills, MCP server card, and llms.txt for discoverability.

- **Content signal preferences** (`public/robots.txt`): Added Content-Signal directives to indicate preferences for AI training (no), search indexing (yes), and AI input usage (yes).

- **Layout integration** (`app/layout.tsx`): Integrated the WebMCP component into the root layout to enable agent tool registration on all pages.

## Implementation Details

- All agent-facing APIs map 1:1 to existing `/api/contact` and `/api/prototype` endpoints, ensuring agents can perform the same actions as human users through forms.
- The markdown middleware is feature-detected and gracefully degrades in non-agent browsers.
- Tool registration uses feature detection to support both `provideContext` and `registerTool` API variants.
- All experimental APIs are wrapped in try-catch to prevent failures from affecting page functionality.

https://claude.ai/code/session_018XYSvjDMTY78u6axBnYgiv