### PR TITLE
Fix mobile hero crowd sizing and restore mobile reveals (disable desktop cursor/magnetics on touch)

### DIFF
--- a/components/CrowdCanvasSpotlight.tsx
+++ b/components/CrowdCanvasSpotlight.tsx
@@ -24,6 +24,8 @@ interface CrowdCanvasSpotlightProps {
 
 type Peep = {
   rect: number[]
+  baseWidth: number
+  baseHeight: number
   width: number
   height: number
   x: number
@@ -86,9 +88,15 @@ export default function CrowdCanvasSpotlight({
 
     const createPeep = ({ rect }: { rect: number[] }): Peep => {
       const peep: Peep = {
-        rect: [], width: 0, height: 0, x: 0, y: 0, anchorY: 0, scaleX: 1, walk: null,
+        rect: [], baseWidth: 0, baseHeight: 0, width: 0, height: 0, x: 0, y: 0, anchorY: 0, scaleX: 1, walk: null,
         color: false, colorIndex: 0,
-        setRect: (r: number[]) => { peep.rect = r; peep.width = r[2]; peep.height = r[3] },
+        setRect: (r: number[]) => {
+          peep.rect = r
+          peep.baseWidth = r[2]
+          peep.baseHeight = r[3]
+          peep.width = r[2]
+          peep.height = r[3]
+        },
         render: (ctx: CanvasRenderingContext2D) => {
           const useColor = peep.color && colorSheet && colorCell.w > 0
           const sheet = useColor ? colorSheet! : bwSheet
@@ -182,10 +190,20 @@ export default function CrowdCanvasSpotlight({
       stage.height = h
       canvas.width = w * devicePixelRatio
       canvas.height = h * devicePixelRatio
+
+      // A full desktop-sized cast overwhelms a narrow screen. Scale the sprites
+      // and reduce the active cast together, keeping the hero lively without
+      // obscuring the headline or turning the lower half into a solid wall.
+      const scale = Math.min(1, Math.max(0.42, w / 900))
+      const activeCount = w < 640 ? Math.min(48, allPeeps.length) : allPeeps.length
+      allPeeps.forEach(p => {
+        p.width = p.baseWidth * scale
+        p.height = p.baseHeight * scale
+      })
       crowd.forEach(p => { p.walk?.kill(); p.color = false })
       crowd.length = 0
       availablePeeps.length = 0
-      availablePeeps.push(...allPeeps)
+      availablePeeps.push(...allPeeps.slice(0, activeCount))
       initCrowd()
     }
 

--- a/components/HomeClientV6.tsx
+++ b/components/HomeClientV6.tsx
@@ -272,15 +272,11 @@ export default function HomeV6() {
     const textEl = cursorTextRef.current
     if (!cursor || !dot || !textEl) return
 
-    if (window.innerWidth <= 768) {
-      cursor.style.display = 'none'; dot.style.display = 'none'; textEl.style.display = 'none'
-      return
-    }
-
     let mouseX = 0, mouseY = 0, curX = 0, curY = 0, dotX = 0, dotY = 0
 
     const handleMouseMove = (e: MouseEvent) => { mouseX = e.clientX; mouseY = e.clientY }
-    document.addEventListener('mousemove', handleMouseMove)
+    const hasFinePointer = window.matchMedia('(hover: hover) and (pointer: fine)').matches
+    if (hasFinePointer) document.addEventListener('mousemove', handleMouseMove)
 
     // GSAP ticker for smooth trailing
     const update = () => {
@@ -295,7 +291,7 @@ export default function HomeV6() {
       textEl.style.left = dotX + 'px'
       textEl.style.top = dotY - 24 + 'px'
     }
-    gsap.ticker.add(update)
+    if (hasFinePointer) gsap.ticker.add(update)
 
     // Magnetic pull for interactive elements
     const magnetics = document.querySelectorAll('a, button, .feature-card, .portfolio-card')
@@ -311,7 +307,7 @@ export default function HomeV6() {
       cursor.style.opacity = '1'
       textEl.classList.remove('active')
     }
-    magnetics.forEach(el => { el.addEventListener('mouseenter', magnetEnter); el.addEventListener('mouseleave', magnetLeave) })
+    if (hasFinePointer) magnetics.forEach(el => { el.addEventListener('mouseenter', magnetEnter); el.addEventListener('mouseleave', magnetLeave) })
 
     // Scroll-fade observer
     const observer = new IntersectionObserver(entries => {
@@ -320,9 +316,11 @@ export default function HomeV6() {
     document.querySelectorAll('.scroll-fade').forEach(el => observer.observe(el))
 
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      gsap.ticker.remove(update)
-      magnetics.forEach(el => { el.removeEventListener('mouseenter', magnetEnter); el.removeEventListener('mouseleave', magnetLeave) })
+      if (hasFinePointer) {
+        document.removeEventListener('mousemove', handleMouseMove)
+        gsap.ticker.remove(update)
+        magnetics.forEach(el => { el.removeEventListener('mouseenter', magnetEnter); el.removeEventListener('mouseleave', magnetLeave) })
+      }
       observer.disconnect()
     }
   }, [])


### PR DESCRIPTION
### Motivation
- Mobile users saw an empty/blank slider area and an overly-crowded hero because desktop-only cursor/magnetic logic prevented mobile reveals and the crowd sprite cast was sized for desktop. 
- The intent is to keep desktop cursor/magnetics for fine-pointer devices while ensuring scroll/fade reveals and the hero crowd remain usable and visually balanced on phones.

### Description
- Replace the early-return that hid cursor behavior on small widths with a `matchMedia` check (`'(hover: hover) and (pointer: fine)'`) so mouse tracking, GSAP ticker and magnetic hover handlers run only on fine-pointer devices while `IntersectionObserver` always runs; changes in `components/HomeClientV6.tsx`.
- Preserve sprite source dimensions by adding `baseWidth` / `baseHeight` to `Peep` and storing them in `setRect`, then compute per-viewport scaled `width`/`height` before seeding the crowd; changes in `components/CrowdCanvasSpotlight.tsx`.
- Scale the sprites and reduce the active cast on narrow screens by computing `scale = Math.min(1, Math.max(0.42, w / 900))` and using `activeCount = w < 640 ? Math.min(48, allPeeps.length) : allPeeps.length`, then pushing `allPeeps.slice(0, activeCount)` into the available pool; changes in `components/CrowdCanvasSpotlight.tsx`.
- Modified files: `components/HomeClientV6.tsx` and `components/CrowdCanvasSpotlight.tsx` (commit message: "Fix mobile reveals and hero crowd sizing").

### Testing
- Type-check: `pnpm exec tsc --noEmit` completed successfully. 
- Production build: `pnpm build` completed and Next compiled successfully. 
- Dev server: `pnpm dev` started and reported the app ready locally. 
- ESLint: `pnpm exec eslint components/HomeClientV6.tsx components/CrowdCanvasSpotlight.tsx` failed due to the repository ESLint config throwing `TypeError: Converting circular structure to JSON` (configuration issue), not due to the code changes. 
- Git checks: `git diff --check` and commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b5bc90e888323af29094b846aa6b3)