### PR TITLE
Make crowd canvas and cursor responsive; refine testimonial mobile layout

### DIFF
--- a/components/CrowdCanvasSpotlight.tsx
+++ b/components/CrowdCanvasSpotlight.tsx
@@ -24,6 +24,8 @@ interface CrowdCanvasSpotlightProps {
 
 type Peep = {
   rect: number[]
+  baseWidth: number
+  baseHeight: number
   width: number
   height: number
   x: number
@@ -86,9 +88,15 @@ export default function CrowdCanvasSpotlight({
 
     const createPeep = ({ rect }: { rect: number[] }): Peep => {
       const peep: Peep = {
-        rect: [], width: 0, height: 0, x: 0, y: 0, anchorY: 0, scaleX: 1, walk: null,
+        rect: [], baseWidth: 0, baseHeight: 0, width: 0, height: 0, x: 0, y: 0, anchorY: 0, scaleX: 1, walk: null,
         color: false, colorIndex: 0,
-        setRect: (r: number[]) => { peep.rect = r; peep.width = r[2]; peep.height = r[3] },
+        setRect: (r: number[]) => {
+          peep.rect = r
+          peep.baseWidth = r[2]
+          peep.baseHeight = r[3]
+          peep.width = r[2]
+          peep.height = r[3]
+        },
         render: (ctx: CanvasRenderingContext2D) => {
           const useColor = peep.color && colorSheet && colorCell.w > 0
           const sheet = useColor ? colorSheet! : bwSheet
@@ -112,7 +120,12 @@ export default function CrowdCanvasSpotlight({
       peep.color = crowd.filter(p => p.color).length < coloredCount
       if (peep.color) peep.colorIndex = nextColorIndex()
       const direction = Math.random() > 0.5 ? 1 : -1
-      const offsetY = 100 - 250 * gsap.parseEase('power2.in')(Math.random())
+      // Keep the mobile crowd inside a tighter vertical band. The desktop range
+      // puts the nearest row mostly below the viewport and the back row too high
+      // once the sprites are scaled down, leaving heads at one edge and cropped
+      // characters at the other.
+      const depth = gsap.parseEase('power2.in')(Math.random())
+      const offsetY = stage.width < 640 ? 25 - 110 * depth : 100 - 250 * depth
       const startY = stage.height - peep.height + offsetY
       let startX: number, endX: number
       if (direction === 1) { startX = -peep.width; endX = stage.width; peep.scaleX = 1 }
@@ -182,10 +195,20 @@ export default function CrowdCanvasSpotlight({
       stage.height = h
       canvas.width = w * devicePixelRatio
       canvas.height = h * devicePixelRatio
+
+      // A full desktop-sized cast overwhelms a narrow screen. Scale the sprites
+      // and reduce the active cast together, keeping the hero lively without
+      // obscuring the headline or turning the lower half into a solid wall.
+      const scale = Math.min(1, Math.max(0.42, w / 900))
+      const activeCount = w < 640 ? Math.min(48, allPeeps.length) : allPeeps.length
+      allPeeps.forEach(p => {
+        p.width = p.baseWidth * scale
+        p.height = p.baseHeight * scale
+      })
       crowd.forEach(p => { p.walk?.kill(); p.color = false })
       crowd.length = 0
       availablePeeps.length = 0
-      availablePeeps.push(...allPeeps)
+      availablePeeps.push(...allPeeps.slice(0, activeCount))
       initCrowd()
     }
 

--- a/components/HomeClientV6.tsx
+++ b/components/HomeClientV6.tsx
@@ -272,15 +272,11 @@ export default function HomeV6() {
     const textEl = cursorTextRef.current
     if (!cursor || !dot || !textEl) return
 
-    if (window.innerWidth <= 768) {
-      cursor.style.display = 'none'; dot.style.display = 'none'; textEl.style.display = 'none'
-      return
-    }
-
     let mouseX = 0, mouseY = 0, curX = 0, curY = 0, dotX = 0, dotY = 0
 
     const handleMouseMove = (e: MouseEvent) => { mouseX = e.clientX; mouseY = e.clientY }
-    document.addEventListener('mousemove', handleMouseMove)
+    const hasFinePointer = window.matchMedia('(hover: hover) and (pointer: fine)').matches
+    if (hasFinePointer) document.addEventListener('mousemove', handleMouseMove)
 
     // GSAP ticker for smooth trailing
     const update = () => {
@@ -295,7 +291,7 @@ export default function HomeV6() {
       textEl.style.left = dotX + 'px'
       textEl.style.top = dotY - 24 + 'px'
     }
-    gsap.ticker.add(update)
+    if (hasFinePointer) gsap.ticker.add(update)
 
     // Magnetic pull for interactive elements
     const magnetics = document.querySelectorAll('a, button, .feature-card, .portfolio-card')
@@ -311,7 +307,7 @@ export default function HomeV6() {
       cursor.style.opacity = '1'
       textEl.classList.remove('active')
     }
-    magnetics.forEach(el => { el.addEventListener('mouseenter', magnetEnter); el.addEventListener('mouseleave', magnetLeave) })
+    if (hasFinePointer) magnetics.forEach(el => { el.addEventListener('mouseenter', magnetEnter); el.addEventListener('mouseleave', magnetLeave) })
 
     // Scroll-fade observer
     const observer = new IntersectionObserver(entries => {
@@ -320,9 +316,11 @@ export default function HomeV6() {
     document.querySelectorAll('.scroll-fade').forEach(el => observer.observe(el))
 
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      gsap.ticker.remove(update)
-      magnetics.forEach(el => { el.removeEventListener('mouseenter', magnetEnter); el.removeEventListener('mouseleave', magnetLeave) })
+      if (hasFinePointer) {
+        document.removeEventListener('mousemove', handleMouseMove)
+        gsap.ticker.remove(update)
+        magnetics.forEach(el => { el.removeEventListener('mouseenter', magnetEnter); el.removeEventListener('mouseleave', magnetLeave) })
+      }
       observer.disconnect()
     }
   }, [])
@@ -663,28 +661,39 @@ export default function HomeV6() {
 
             <div className="flex flex-col gap-8">
               {testimonials.map((t, i) => (
-                <div key={i} className="bg-[var(--cream)] rounded-2xl p-6 md:p-8 scroll-fade" style={{ transitionDelay: `${i * 100}ms` }}>
+                <div key={i} className="bg-[var(--cream)] rounded-2xl p-5 md:p-8 scroll-fade" style={{ transitionDelay: `${i * 100}ms` }}>
                   <div className="grid grid-cols-1 md:grid-cols-[1fr_180px] gap-6 md:gap-8">
                     {/* Left: quotes + attribution */}
                     <div className="flex flex-col">
+                      {/* On phones, lead with a compact identity row instead of
+                          placing a large portrait underneath the entire quote. */}
+                      <div className="flex items-center gap-3 mb-5 md:hidden">
+                        <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-xl">
+                          <Image src={t.image} alt={t.name} fill className="object-cover" style={{ objectPosition: t.imgPos }} sizes="56px" />
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold tracking-tight text-[var(--black)]">{t.name}</p>
+                          <p className="text-xs leading-snug text-[var(--gray-medium)]">{t.role}</p>
+                        </div>
+                      </div>
                       {/* Pull quote */}
-                      <p className="text-[clamp(22px,3vw,32px)] font-light leading-snug tracking-tight text-[var(--black)] mb-4">
+                      <p className="text-xl md:text-[clamp(22px,3vw,32px)] font-light leading-snug tracking-tight text-[var(--black)] mb-4">
                         &ldquo;...{t.highlight}&rdquo;
                       </p>
                       {/* Full quote with left accent */}
-                      <div className="border-l-[3px] border-[var(--gray-medium)]/20 pl-5 mb-5">
-                        <p className="text-[15px] leading-relaxed text-[var(--gray-medium)]">
+                      <div className="border-l-2 md:border-l-[3px] border-[var(--gray-medium)]/20 pl-4 md:pl-5 md:mb-5">
+                        <p className="text-sm md:text-[15px] leading-relaxed text-[var(--gray-medium)]">
                           &ldquo;{t.quote}&rdquo;
                         </p>
                       </div>
                       {/* Attribution — moved here from the right column */}
-                      <div>
+                      <div className="hidden md:block">
                         <p className="text-sm text-[var(--gray-medium)]">{t.name}</p>
                         <p className="text-sm font-semibold tracking-tight">{t.role}</p>
                       </div>
                     </div>
                     {/* Right: photo only */}
-                    <div className="w-40 h-48 md:w-full md:h-full rounded-xl overflow-hidden relative">
+                    <div className="hidden md:block md:w-full md:h-full rounded-xl overflow-hidden relative">
                       <Image src={t.image} alt={t.name} fill className="object-cover" style={{ objectPosition: t.imgPos }} sizes="180px" />
                     </div>
                   </div>


### PR DESCRIPTION
### Motivation

- Improve the crowd sprite staging so desktop casts don't overwhelm narrow screens and so sprites remain visually correct when scaled. 
- Avoid running the upgraded custom cursor and magnetic interactions on touch or coarse-pointer devices to reduce jank and unnecessary event listeners. 
- Improve testimonial readability and portrait placement on small screens so quotes and attribution don't get visually crowded.

### Description

- In `components/CrowdCanvasSpotlight.tsx` added `baseWidth`/`baseHeight` to the `Peep` model, set those in `setRect`, and scale every sprite on `resize` using a computed `scale` so sprites shrink smoothly on narrow viewports. 
- Also in `CrowdCanvasSpotlight.tsx` constrained the active cast with an `activeCount` computed from the canvas width, sliced `availablePeeps` accordingly, and tightened the vertical offset band for small screens so heads/feet aren't cropped. 
- In `components/HomeClientV6.tsx` gated the custom cursor, GSAP ticker, and magnetic hover handlers behind `window.matchMedia('(hover: hover) and (pointer: fine)')` so these features only activate for fine-pointer (desktop) devices and are cleaned up conditionally. 
- Adjusted the testimonials markup and classes to reduce padding on the card, introduce a compact identity row on phones, move attribution into the quote column for desktop, and tweak type/border sizing for better small-screen presentation.

### Testing

- Ran TypeScript typecheck (`tsc --noEmit`) and it completed successfully. 
- Ran linter (`yarn lint`) with no new errors. 
- Ran the unit test suite (`yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b5bc90e888323af29094b846aa6b3)